### PR TITLE
refactor(cronjob): remove global tag requirement

### DIFF
--- a/cronjob/Chart.yaml
+++ b/cronjob/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cronjob
 description: A generic Helm chart for Kubernetes cronjobs
 type: application
-version: 1.0.0
+version: 1.1.0

--- a/cronjob/README.md
+++ b/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic Helm chart for Kubernetes cronjobs
 

--- a/cronjob/templates/cronjob.yml
+++ b/cronjob/templates/cronjob.yml
@@ -2,18 +2,22 @@
 {{- $chart_labels := include "cronjob.labels" . }}
 {{- $chart_selector_labels := include "cronjob.selectorLabels" . }}
 {{- $service_account_name := include "cronjob.serviceAccountName" . }}
-{{- $tag := .Values.image.tag }}
 {{- $image_pull_secrets := .Values.imagePullSecrets }}
 
+{{- $globalRepository := (and $.Values.image $.Values.image.repository) }}
+{{- $globalTag := (and $.Values.image $.Values.image.tag) }}
+{{- $globalPullPolicy := (and $.Values.image $.Values.image.pullPolicy) }}
+
 {{- range $job := .Values.jobs }}
-{{- $image := print $.Values.image.repository ":" $tag }}
-{{- $image_pull_policy := $.Values.image.pullPolicy }}
-{{- if .image }}
-  {{- $image = print .image.repository ":" (default $tag .image.tag) }}
-  {{- if .image.pullPolicy }}
-    {{- $image_pull_policy = .image.pullPolicy }}
-  {{- end }}
-{{- end }}
+
+{{- $jobRepository := (and $job.image $job.image.repository) }}
+{{- $jobTag := (and $job.image $job.image.tag) }}
+{{- $jobPullPolicy := (and $job.image $job.image.pullPolicy) }}
+
+{{- $repo := required (printf "Repository is required for job %q! Set jobs[].image.repository or global image.repository" $job.name) (coalesce $jobRepository $globalRepository) }}
+{{- $tag := required (printf "Tag is required for job %q! Set either jobs[].image.tag or global image.tag" $job.name) (coalesce $jobTag $globalTag) }}
+{{- $image := printf "%s:%s" $repo $tag }}
+{{- $image_pull_policy := coalesce $jobPullPolicy $globalPullPolicy }}
 
 {{- $env := $.Values.env }}
 {{- if .env }}

--- a/cronjob/values.yaml
+++ b/cronjob/values.yaml
@@ -1,6 +1,12 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# image:
+#   # -- Specifies a default image for all jobs without image definition
+#   repository: docker.io/schulcloud/cron-tools
+#   tag: latest
+#   pullPolicy: IfNotPresent
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true
@@ -120,5 +126,3 @@ jobs: []
   #   extraVolumeMounts: []
   #   # -- Additional job specific volumes
   #   extraVolumes: []
-
-


### PR DESCRIPTION
# Description

- Removed the requirement to have a tag defined globally
- A helm chart user can now use the either the job specific image values or the global ones
- If no repo or tag definition is configured the user will see an error message to define those values either globally or per job
- Job definition wins over global definition
- Added commented out global image configuration to hint users for the possibility to have image configured globally
- bumped version 1.0.0 -> 1.1.0